### PR TITLE
add -default on button sizes docs to make it look cleaner example

### DIFF
--- a/docs/dist/script.js
+++ b/docs/dist/script.js
@@ -28013,22 +28013,22 @@
 	            { className: "doc-btn-group" },
 	            _react2["default"].createElement(
 	              "button",
-	              { className: "btn -xs" },
+	              { className: "btn -default -xs" },
 	              "Extra Small"
 	            ),
 	            _react2["default"].createElement(
 	              "button",
-	              { className: "btn -small" },
+	              { className: "btn -default -small" },
 	              "Small"
 	            ),
 	            _react2["default"].createElement(
 	              "button",
-	              { className: "btn" },
+	              { className: "btn -default" },
 	              "Default"
 	            ),
 	            _react2["default"].createElement(
 	              "button",
-	              { className: "btn -large" },
+	              { className: "btn -default -large" },
 	              "Large"
 	            )
 	          )

--- a/docs/sections/Docs-Buttons/index.jsx
+++ b/docs/sections/Docs-Buttons/index.jsx
@@ -26,10 +26,10 @@ export default class Buttons extends React.Component {
           <h3 className="doc-heading">Sizes</h3>
           <p>Apply one of .-xs, .-small, .-large</p>
           <div className="doc-btn-group">
-            <button className="btn -xs">Extra Small</button>
-            <button className="btn -small">Small</button>
-            <button className="btn">Default</button>
-            <button className="btn -large">Large</button>
+            <button className="btn -default -xs">Extra Small</button>
+            <button className="btn -default -small">Small</button>
+            <button className="btn -default">Default</button>
+            <button className="btn -default -large">Large</button>
           </div>
           
         </section>


### PR DESCRIPTION
Just to look good :+1: 

![image](https://cloud.githubusercontent.com/assets/12628112/10932766/82f33022-830e-11e5-843b-7de6d1619c28.png)
