### PR TITLE
update link color for alert

### DIFF
--- a/docs/dist/script.js
+++ b/docs/dist/script.js
@@ -28090,7 +28090,7 @@
 	          _react2["default"].createElement(
 	            "h3",
 	            { className: "doc-heading" },
-	            "Example: Links"
+	            "Example: Alert with links"
 	          ),
 	          _react2["default"].createElement(
 	            "p",
@@ -28148,7 +28148,7 @@
 	          _react2["default"].createElement(
 	            "h3",
 	            { className: "doc-heading" },
-	            "Example: Block"
+	            "Example: Alert in block"
 	          ),
 	          _react2["default"].createElement(
 	            "p",
@@ -28167,12 +28167,18 @@
 	          _react2["default"].createElement(
 	            "h3",
 	            { className: "doc-heading" },
-	            "Example: Large"
+	            "Example: Alert in Large size"
 	          ),
 	          _react2["default"].createElement(
 	            "p",
 	            null,
-	            "Simply apply the .-large class."
+	            "Simply apply the ",
+	            _react2["default"].createElement(
+	              "code",
+	              null,
+	              ".-large"
+	            ),
+	            " class."
 	          ),
 	          _react2["default"].createElement(
 	            "div",
@@ -28186,7 +28192,7 @@
 	          _react2["default"].createElement(
 	            "h3",
 	            { className: "doc-heading" },
-	            "Example: With Icons"
+	            "Example: Alert with icons"
 	          ),
 	          _react2["default"].createElement(
 	            "div",
@@ -28201,7 +28207,7 @@
 	          _react2["default"].createElement(
 	            "h3",
 	            { className: "doc-heading" },
-	            "Growl"
+	            "Example: Alert as Growl"
 	          ),
 	          _react2["default"].createElement(
 	            "p",

--- a/docs/dist/style.css
+++ b/docs/dist/style.css
@@ -5820,10 +5820,10 @@ hr {
   position: relative;
   color: #fff;
   border-radius: 5px; }
-  .alert.-emerald {
-    background-color: #38D4A9; }
   .alert.-sky {
     background-color: #52B5E5; }
+  .alert.-emerald {
+    background-color: #38D4A9; }
   .alert.-sun {
     background-color: #FFC05A; }
   .alert.-crimson {
@@ -5839,13 +5839,13 @@ hr {
   .alert a {
     font-weight: bold; }
   .alert.-sky a {
-    color: #2F5B86; }
+    color: #156389; }
   .alert.-emerald a {
-    color: #227D64; }
+    color: #145f4a; }
   .alert.-sun a {
-    color: #80612E; }
+    color: #c07700; }
   .alert.-crimson a {
-    color: #86342C; }
+    color: #9a1a0d; }
 
 .alert-growl {
   position: fixed;

--- a/docs/sections/Docs-Alerts/index.jsx
+++ b/docs/sections/Docs-Alerts/index.jsx
@@ -44,7 +44,7 @@ export default class Alerts extends React.Component {
         </section>
 
         <section className="doc-bottom-space">
-          <h3 className="doc-heading">Example: Links</h3>
+          <h3 className="doc-heading">Example: Alert with links</h3>
           <p>Links are boldened and given a darker shade of the variant's color.</p>
 
           <div className="alert -sky doc-bottom-space">
@@ -65,7 +65,7 @@ export default class Alerts extends React.Component {
         </section>
 
         <section className="doc-bottom-space">
-          <h3 className="doc-heading">Example: Block</h3>
+          <h3 className="doc-heading">Example: Alert in block</h3>
           <p>Useful when you'd like to use a more emphasized alert (for example, growl).</p>
           <div className="alert -emerald -block">
             Oh snap! Change a few things up and try this submitting again.
@@ -73,15 +73,15 @@ export default class Alerts extends React.Component {
         </section>
 
         <section className="doc-bottom-space">
-          <h3 className="doc-heading">Example: Large</h3>
-          <p>Simply apply the .-large class.</p>
+          <h3 className="doc-heading">Example: Alert in Large size</h3>
+          <p>Simply apply the <code>.-large</code> class.</p>
           <div className="alert -emerald -large">
             Oh snap! Change a few things up and try this submitting again.
           </div>
         </section>
 
         <section className="doc-bottom-space-large">
-          <h3 className="doc-heading">Example: With Icons</h3>
+          <h3 className="doc-heading">Example: Alert with icons</h3>
           <div className="alert -crimson">
             <i className="icon icon-alert" />
             Oh snap! Change a few things up and try this submitting again.
@@ -89,7 +89,7 @@ export default class Alerts extends React.Component {
         </section>
 
         <section>
-          <h3 className="doc-heading">Growl</h3>
+          <h3 className="doc-heading">Example: Alert as Growl</h3>
           <p className="lead">This is useful for notifying the user of an update with a pop-up message.</p>
           <div className="alert -sky _spacer">
             According to <a href="https://en.wikipedia.org/wiki/Growl_(software)">Wikipedia</a>, Growl is a global notification system and pop-up notification implementation.

--- a/styles/_colors.scss
+++ b/styles/_colors.scss
@@ -13,13 +13,13 @@ $brand-sidebar-dk: #0B121F !default;
 
 // color variations
 $brand-primary: #3A569B !default;
-$brand-primary-dk: #283C6F !default;
 // light / neutral colors
 $brand-sky: #52B5E5 !default; // blue
 $brand-emerald: #38D4A9 !default; // primary | gren
 $brand-sun: #FFC05A !default; // yellow
 $brand-crimson: #F05F50 !default; // red
 // dark colors
+$brand-primary-dk: #283C6F !default;
 $brand-sky-dk: #4684BF !default;
 $brand-emerald-dk: #2EAF8B !default;
 $brand-sun-dk: #C99746 !default;

--- a/styles/components/_alert.scss
+++ b/styles/components/_alert.scss
@@ -4,12 +4,12 @@
 	color: $brand-white;
   border-radius: $border-radius-base;
 
-  &.-emerald {
-    background-color: $brand-emerald;
-  }
-
   &.-sky {
     background-color : $brand-sky;
+  }
+
+  &.-emerald {
+    background-color : $brand-emerald;
   }
 
   &.-sun {
@@ -38,22 +38,19 @@
     font-weight: bold;
   }
 
-  // @todo
-  // Document all alert link colors somehow.
-  // Or even set to a variable
   &.-sky a {
-    color: #2F5B86;
+    color: darken($brand-sky,30%);
   }
 
   &.-emerald a {
-    color: #227D64;
+    color: darken($brand-emerald,30%);
   }
 
   &.-sun a {
-    color: #80612E;
+    color: darken($brand-sun,30%);
   }
 
   &.-crimson a {
-    color: #86342C;
+    color: darken($brand-crimson,30%);
   }
 }


### PR DESCRIPTION
Resolves #201 

After thinking an hour for what's the best way,i ended up this as my best answer.
- totally removed the color that's not part of our `_variable.scss`
- maximize `SASS` by using its HSL Function `darken`
- darken color by 30% 

example code my look like:
`color : darken($brand-primary,30%);`

with this way, link color in alert are connected to our `_variable.scss`
![image](https://cloud.githubusercontent.com/assets/12628112/11390663/4dc49ec0-9387-11e5-80f4-847aea66de88.png)

---
### These are the 2 other choices although not consider them because of its individual reason....

---
## Use the dark version of the color
- Not good because its a bit more light and it gives not so much emphasis onto the alert links
- example code: `color: $brand-primary-dk;`

![image](https://cloud.githubusercontent.com/assets/12628112/11391056/7f128a16-938a-11e5-9799-d60c7570a623.png)

---
## Use the dark version of the color and SASS HSL Function Darken combination
- Not use because IMO, its a redundant to read
- example code: `color: darken($brand-primary-dk,25%);`

![image](https://cloud.githubusercontent.com/assets/12628112/11391094/dcdbf5d8-938a-11e5-85d8-52ac0ba2534f.png)

---

Any thoughts or suggestion? @srph 
